### PR TITLE
fixed typo that prevented build from succeeding

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -27,7 +27,7 @@
     {{ partial "header.html" . }}
 
     {{ $displaySidebar := false }}
-    {{ range site.Params.mainSections }}
+    {{ range .Site.Params.mainSections }}
     {{ if eq $.Section . }}
     {{ $displaySidebar = true }}
     {{ end }}


### PR DESCRIPTION
Error: "themes\hugo-whisper-theme\layouts\_default\baseof.html:30:1": parse master failed: template: index.html:30: function "site" not defined