### PR TITLE
Fix typo for homepage_button_text param

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -21,7 +21,7 @@ pygmentsUseClasses = true
 [params]
   google_analytics_id=""
   homepage_button_link = '/docs'
-  homeoage_button_text = 'Read The Docs'
+  homepage_button_text = 'Read The Docs'
   homepage_intro = 'Whisper is a documentation theme built with Hugo. The design and functionality is intentionally minimal.'
   homepage_image = '/images/terminal.gif'
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -29,7 +29,7 @@
           {{ end }}
         </div>
         <a class="button button-primary mb-2" href="{{ .Site.Params.homepage_button_link | relURL }}">
-          {{ .Site.Params.homeoage_button_text }}
+          {{ .Site.Params.homepage_button_text }}
         </a>
       </div>
     </div>


### PR DESCRIPTION
Fixes typo in layout and example site. Closes #7.