### PR TITLE
Use Hugo's content summary feature for documentation overview

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -8,6 +8,10 @@ pygmentsCodeFences = true
 pygmentsCodefencesGuessSyntax = true
 pygmentsUseClasses = true
 
+# Controls how many words are printed in the content summary on the docs homepage.
+# See https://gohugo.io/content-management/summaries/
+summaryLength = 30
+
 [[menu.main]]
     name = "Home"
     url = "/"

--- a/exampleSite/content/docs/configure/index.md
+++ b/exampleSite/content/docs/configure/index.md
@@ -3,6 +3,7 @@ title: 'Configuration'
 date: 2019-02-11T19:30:08+10:00
 draft: false
 weight: 4
+summary: Syntax highlighting and menus can be configured via `config.toml`.
 ---
 
 ## Syntax Highlighting

--- a/exampleSite/content/docs/example/index.md
+++ b/exampleSite/content/docs/example/index.md
@@ -6,6 +6,8 @@ weight: 7
 
 Whisper is a minimal documentation theme built for Hugo. The design and functionality is intentionally minimal.
 
+<!--more-->
+
 ## Quickstart
 
 Copy or git clone this theme into the sites themes folder `mynewsite/themes`

--- a/exampleSite/content/docs/example/index.md
+++ b/exampleSite/content/docs/example/index.md
@@ -4,7 +4,7 @@ date: 2019-02-11T19:27:37+10:00
 weight: 7
 ---
 
-Whisper is a minimal documentation theme built for Hugo. The design and functionality is intentionally minimal.
+Whisper is a minimal documentation theme built for Hugo. The design &amp; functionality is intentionally minimal.
 
 <!--more-->
 

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -3,5 +3,5 @@
   <img alt="{{ .Title }}" src="{{ .Params.image }}" />
   {{ end}}
   <h2 class="title-summary"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
-  <p>{{ htmlUnescape .Content | plainify | truncate 140 }}</p>
+  <p>{{ .Summary }}</p>
 </div>


### PR DESCRIPTION
The summary partial uses Hugo's [content summary](https://gohugo.io/content-management/summaries/) feature to populate the documentation previews on the Docs overview page.

I've also added a few examples in the example site of how to customize the summary for individual pages, as well as how to customize the default summary word count.

The summary feature does the right thing with partial html tags and encoded characters, so I also removed the `htmlUnescape` and `plainify` filters.

Fixes #19 