### PR TITLE
Fix docs weight order

### DIFF
--- a/exampleSite/content/docs/example/index.md
+++ b/exampleSite/content/docs/example/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Hugo Whisper'
 date: 2019-02-11T19:27:37+10:00
-weight: 7
+weight: 6
 ---
 
 Whisper is a minimal documentation theme built for Hugo. The design &amp; functionality is intentionally minimal.

--- a/exampleSite/content/docs/specimen/index.md
+++ b/exampleSite/content/docs/specimen/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Specimen'
 date: 2019-02-11T19:27:37+10:00
-weight: 6
+weight: 5
 ---
 
 # <a name="top"></a>Markdown Test Page


### PR DESCRIPTION
A minor change to the order of docs weights. Weight of `Configuration` is 4. The next one is `Specimen`, which is set to 6. Should be 5 and so on.

Great theme ❤️ 