### PR TITLE
Allow overriding color

### DIFF
--- a/assets/scss/_bootstrap-variables.scss
+++ b/assets/scss/_bootstrap-variables.scss
@@ -15,9 +15,9 @@ $container-max-widths: (
 
 $grid-gutter-width: 20px;
 
-$primary: #1de9b6;
-$secondary: #ffca28;
-$black: #212529;
+$primary: #1de9b6 !default;
+$secondary: #ffca28 !default;
+$black: #212529 !default;
 
 // Links
 $link-color: $primary;


### PR DESCRIPTION
When just the colors, not the entire SCSS, are to be defined outside the theme, the theme's own definition of the colors are just to be marked `default`; SCSS/Sass will use these colors as fallback when the site doesn't override them.

Refer: https://stackoverflow.com/a/17090334