### PR TITLE
fix `.Site.IsServer` error (#1)

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -10,7 +10,7 @@ pygmentsUseClasses = true
 [module]
   [module.hugoVersion]
     extended = true
-    min = "0.55.0"
+    min = "0.120.0"
 
 # Controls how many words are printed in the content summary on the docs homepage.
 # See https://gohugo.io/content-management/summaries/

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,8 +9,13 @@
   {{ block "meta_tags" . }}{{end}}
   <link rel="icon" href="{{ "favicon.png" | absURL}}">
 
+  {{ if hugo.IsServer }}
+  {{ $style := resources.Get "scss/style.scss" | toCSS (dict "targetPath" "css/style.css" "enableSourceMap" true) }}
+  <link rel="stylesheet" href="{{ ($style).RelPermalink }}">
+  {{ else }}
   {{ $style := resources.Get "scss/style.scss" | toCSS (dict "targetPath" "css/style.css" "enableSourceMap" false) }}
   <link rel="stylesheet" href="{{ ($style | minify | fingerprint).RelPermalink }}">
+  {{ end }}
 
   {{ block "header_css" . }}{{ end }}
 
@@ -55,7 +60,11 @@
   {{ block "footer_js" . }}
   {{ end }}
 
+  {{ if hugo.IsServer }}
+  <script type="text/javascript" src="{{ $scripts.RelPermalink }}"></script>
+  {{ else }}
   <script type="text/javascript" src="{{ ($scripts | minify | fingerprint).RelPermalink }}"></script>
+  {{ end }}
 
   {{ partial "google-analytics.html" . }}
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,13 +9,8 @@
   {{ block "meta_tags" . }}{{end}}
   <link rel="icon" href="{{ "favicon.png" | absURL}}">
 
-  {{ if .Site.IsServer }}
-  {{ $style := resources.Get "scss/style.scss" | toCSS (dict "targetPath" "css/style.css" "enableSourceMap" true) }}
-  <link rel="stylesheet" href="{{ ($style).RelPermalink }}">
-  {{ else }}
   {{ $style := resources.Get "scss/style.scss" | toCSS (dict "targetPath" "css/style.css" "enableSourceMap" false) }}
   <link rel="stylesheet" href="{{ ($style | minify | fingerprint).RelPermalink }}">
-  {{ end }}
 
   {{ block "header_css" . }}{{ end }}
 
@@ -60,11 +55,7 @@
   {{ block "footer_js" . }}
   {{ end }}
 
-  {{ if .Site.IsServer }}
-  <script type="text/javascript" src="{{ $scripts.RelPermalink }}"></script>
-  {{ else }}
   <script type="text/javascript" src="{{ ($scripts | minify | fingerprint).RelPermalink }}"></script>
-  {{ end }}
 
   {{ partial "google-analytics.html" . }}
 

--- a/layouts/partials/google-analytics.html
+++ b/layouts/partials/google-analytics.html
@@ -1,26 +1,22 @@
-{{- if .Site.IsServer -}}
-  <!-- Dont add Google analytics to localhost -->
+{{ $gid := (getenv "HUGO_GOOGLE_ANALYTICS_ID") }}
+{{ if $gid }}
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{- $gid -}}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '{{- $gid -}}');
+  </script>
 {{ else }}
-  {{ $gid := (getenv "HUGO_GOOGLE_ANALYTICS_ID") }}
-  {{ if $gid }}
+  {{ if .Site.Params.google_analytics_id }}
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{- $gid -}}"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{- .Site.Params.google_analytics_id -}}"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', '{{- $gid -}}');
+      gtag('config', '{{- .Site.Params.google_analytics_id -}}');
     </script>
-  {{ else }}
-    {{ if .Site.Params.google_analytics_id }}
-      <!-- Global site tag (gtag.js) - Google Analytics -->
-      <script async src="https://www.googletagmanager.com/gtag/js?id={{- .Site.Params.google_analytics_id -}}"></script>
-      <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', '{{- .Site.Params.google_analytics_id -}}');
-      </script>
-    {{ end }}
-  {{ end}}
-{{ end }}
+  {{ end }}
+{{ end}}

--- a/layouts/partials/google-analytics.html
+++ b/layouts/partials/google-analytics.html
@@ -1,22 +1,26 @@
-{{ $gid := (getenv "HUGO_GOOGLE_ANALYTICS_ID") }}
-{{ if $gid }}
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id={{- $gid -}}"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', '{{- $gid -}}');
-  </script>
+{{- if hugo.IsServer -}}
+  <!-- Dont add Google analytics to localhost -->
 {{ else }}
-  {{ if .Site.Params.google_analytics_id }}
+  {{ $gid := (getenv "HUGO_GOOGLE_ANALYTICS_ID") }}
+  {{ if $gid }}
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{- .Site.Params.google_analytics_id -}}"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{- $gid -}}"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', '{{- .Site.Params.google_analytics_id -}}');
+      gtag('config', '{{- $gid -}}');
     </script>
-  {{ end }}
-{{ end}}
+  {{ else }}
+    {{ if .Site.Params.google_analytics_id }}
+      <!-- Global site tag (gtag.js) - Google Analytics -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{- .Site.Params.google_analytics_id -}}"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '{{- .Site.Params.google_analytics_id -}}');
+      </script>
+    {{ end }}
+  {{ end}}
+{{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,6 @@
   command = "cd exampleSite && hugo --gc --themesDir ../.."
 
 [build.environment]
-  HUGO_VERSION = "0.80.0"
+  HUGO_VERSION = "0.120.0"
   HUGO_THEME = "repo"
   HUGO_BASEURL = "/"


### PR DESCRIPTION
The new version of Hugo seems to not support <.Site.IsServer>. Including it in the code will cause errors. This PR removes <.Site.IsServer> so that the theme can use continuous integration more easily.